### PR TITLE
Fix cross-platform macro and destructor

### DIFF
--- a/Loom/include/Loom/Core/Application.h
+++ b/Loom/include/Loom/Core/Application.h
@@ -10,7 +10,7 @@ namespace Loom
     {
         public:
             Application();
-            ~Application();
+            virtual ~Application();
 
             void Run();
    };

--- a/Loom/include/Loom/Core/Core.h
+++ b/Loom/include/Loom/Core/Core.h
@@ -8,4 +8,6 @@
     #else
         #define LOOM_API __declspec(dllimport)
     #endif
+#else
+    #define LOOM_API
 #endif


### PR DESCRIPTION
## Summary
- make `LOOM_API` an empty macro on non‑Windows platforms
- make `Application` destructor virtual

## Testing
- `cmake ..`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_684d809b26148322976d7a4d9f48f40f